### PR TITLE
Display snackbar from a future

### DIFF
--- a/lib/view/chat_widget.dart
+++ b/lib/view/chat_widget.dart
@@ -116,8 +116,10 @@ class _ChatWidgetState extends State<ChatWidget> {
                           },
                         );
                       } else if (snapshot.hasError) {
-                        Components.snackBar(context, snapshot.error,
-                            Theme.of(context).errorColor);
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          Components.snackBar(context, snapshot.error,
+                              Theme.of(context).errorColor);
+                        });
                       }
                       return Center(child: CircularProgressIndicator());
                     }))));


### PR DESCRIPTION
Il n'est pas possible d'afficher une snackbar depuis un future builder : il faut retarder son exécution à l'issue du widget build.